### PR TITLE
Add `coreutils` to prevent RISC-V toolchain build errors

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,39 +1,39 @@
 FROM ubuntu:20.04 as builder
 
-# Install dependancies
+# Install dependencies
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y lcov \
     libelf1 libelf-dev libftdi1-2 libftdi1-dev libncurses5 libssl-dev \
     libudev-dev libusb-1.0-0 lsb-release texinfo autoconf cmake flex bison \
     libexpat-dev gawk tree xterm python3-venv python3-dev \
-    git wget python3 \
+    git wget python3 build-essential make coreutils \
     && rm -rf /var/lib/apt/lists/*
 
 # Install GCC-RISC-V toolchain
-RUN git clone --branch 2022.01.17 --recursive https://github.com/riscv/riscv-gnu-toolchain /riscv-gnu-toolchain
-RUN cd /riscv-gnu-toolchain && ./configure --prefix=/tools/riscv --with-arch=rv32imc --with-abi=ilp32
-RUN apt update && apt install -y gcc build-essential make
-RUN cd /riscv-gnu-toolchain && make
-RUN rm riscv-gnu-toolchain -rf
 ENV RISCV=/tools/riscv
+RUN git clone --branch 2022.01.17 --recursive https://github.com/riscv/riscv-gnu-toolchain /riscv-gnu-toolchain
+RUN cd /riscv-gnu-toolchain && ./configure --prefix=${RISCV} --with-arch=rv32imc --with-abi=ilp32
+RUN cd /riscv-gnu-toolchain && make -j$(nproc)
+RUN rm -rf /riscv-gnu-toolchain
 
 # Install clang
 RUN git clone https://github.com/llvm/llvm-project.git /llvm-project
 RUN cd /llvm-project && git checkout llvmorg-14.0.0 && mkdir build 
 RUN cd /llvm-project/build && cmake -G "Unix Makefiles" -DLLVM_ENABLE_PROJECTS=clang -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$RISCV -DLLVM_TARGETS_TO_BUILD="RISCV" ../llvm
 RUN cd /llvm-project/build && cmake --build . --target install
+RUN rm -rf /llvm-project
 
 # Install Verilator
 ENV VERILATOR_VERSION=4.210
 RUN git clone https://github.com/verilator/verilator.git && cd verilator && git checkout v$VERILATOR_VERSION
 RUN cd /verilator && autoconf && ./configure --prefix=/tools/verilator/$VERILATOR_VERSION
 RUN cd /verilator && make && make install
-RUN rm verilator -rf
+RUN rm -rf /verilator
 
 # Install Verible
 ENV VERIBLE_VERSION=v0.0-2135-gb534c1fe
 RUN wget https://github.com/google/verible/releases/download/${VERIBLE_VERSION}/verible-${VERIBLE_VERSION}-Ubuntu-20.04-focal-x86_64.tar.gz
 RUN mkdir -p /tools/verible && tar -xf verible-${VERIBLE_VERSION}-Ubuntu-20.04-focal-x86_64.tar.gz -C /tools/verible/
-RUN rm verible-${VERIBLE_VERSION}-Ubuntu-20.04-focal-x86_64.tar.gz
+RUN rm -rf verible-${VERIBLE_VERSION}-Ubuntu-20.04-focal-x86_64.tar.gz
 
 # Install conda
 RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
@@ -55,7 +55,7 @@ RUN /opt/conda/bin/conda env create -f environment.yml
 # FROM gcr.io/distroless/cc-debian11
 
 # # Copy RISC-V toolchain from builder
-# COPY --from=builder /tools/riscv /tools/riscv
+# COPY --from=builder ${RISCV} ${RISCV}
 # COPY --from=builder /tools/verilator /tools/verilator
 # COPY --from=builder /usr/bin/perl /usr/bin/perl
 # COPY --from=builder /usr/bin/env /usr/bin/env
@@ -81,9 +81,7 @@ RUN /opt/conda/bin/conda env create -f environment.yml
 # COPY --from=busybox /bin/echo /bin/echo
 # COPY --from=busybox /bin/tee /bin/tee
 
-ENV RISCV=/tools/riscv
-
-ENV PATH=/tools/verible/verible-v0.0-2135-gb534c1fe:/tools/verilator/4.210/bin/:/opt/conda/envs/core-v-mini-mcu/bin:/opt/conda/condabin:/tools/riscv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV PATH=/tools/verible/verible-${VERIBLE_VERSION}:/tools/verilator/${VERILATOR_VERSION}/bin/:/opt/conda/envs/core-v-mini-mcu/bin:/opt/conda/condabin:${RISCV}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 WORKDIR /workspace/x-heep
 


### PR DESCRIPTION
## Description
- Add `coreutils` to list of packages to install to prevent GCC toolchain compilation errors.
- Remove duplicate `RISCV` variable definition
- Use version variables when setting `PATH`